### PR TITLE
Filter refactor

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,7 @@ import React, { useState, useContext, useEffect } from 'react';
 import { setLocalStorage, getLocalStorage } from './js/Storage.js';
 import { useLoadProfile, useSaveProfile } from "./js/Profile.js";
 
-import { FilterFunction, FilterContext } from "./context/Filter.js";
+import { FilterFunction, FilterProvider, FilterContext } from "./context/Filter.js";
 import { ProfileContext } from "./context/Profile.js";
 import { ItemsContext } from "./context/Items.js";
 
@@ -14,7 +14,7 @@ import './App.css';
 const data = require('./data/data.json');
 
 function Main(props) {
-  const filterContext = useContext(FilterContext);
+  const filters = useContext(FilterContext);
   const filterFunction = useContext(FilterFunction);
   const saveProfile = useSaveProfile();
   const loadProfile = useLoadProfile();
@@ -26,7 +26,7 @@ function Main(props) {
   return (
     <div className="main">
       <p className="main__title">{ data.title }</p>
-      <FilterBar data={ data.filters } />
+      <FilterBar filters={filters.filters} />
       <ItemList data={ props.filteredData } />
     </div>
   );
@@ -36,7 +36,7 @@ function App() {
   const [filteredData, setFilteredData] = useState(data.items);
 
   return (
-    <FilterContext.Provider value={ data.filters }>
+    <FilterProvider>
     <FilterFunction.Provider value={ setFilteredData }>
     <ItemsContext.Provider value={ [] }>
     <ProfileContext.Provider value={ '' }>
@@ -44,7 +44,7 @@ function App() {
     </ProfileContext.Provider>
     </ItemsContext.Provider>
     </FilterFunction.Provider>
-    </FilterContext.Provider>
+    </FilterProvider>
   );
 }
 

--- a/src/components/Filters.js
+++ b/src/components/Filters.js
@@ -1,38 +1,45 @@
-import FilterData, { useUpdateFilterState } from '../js/Filter.js';
+import { useContext } from 'react'
+import { FilterContext } from '../context/Filter'
+import { useUpdateFilterState } from '../js/Filter.js'
 
-function FilterBar(props) {
-  var filterSections = []
-  for (var i = 0; i < props.data.length; i++) {
-    filterSections.push(<FilterSection data={ props.data[i] } key={i} />)
-  }
-  return (
-    <div className="filters">
-      { filterSections }
-    </div>
-  );
-}
+const FilterBar = ({ filters }) => (
+  <div className="filters">
+    {filters.map(f => (
+      <FilterSection key={f.name} title={f.title} filters={f.items} sectionName={f.name} />
+    ))}
+  </div>
+);
 
-function FilterSection(props) {
-  var filters = []
-  for (var i = 0; i < props.data.items.length; i++) {
-    filters.push(<Filter name={props.data.name} data={ props.data.items[i] } key={i} />)
-  }
-  return (
-    <div className="filters__section">
-      <h4 className="filters__title">{ props.data.title }</h4>
-      { filters }
-    </div>
-  );
-}
+const FilterSection = ({ title, filters, sectionName }) => (
+  <div className="filters__section">
+    <h4 className="filters__title">{title}</h4>
+    {filters.map(f => (
+      <Filter name={f.name} key={f.name} label={f.label} sectionName={sectionName} />
+    ))}
+  </div>
+)
 
-function Filter(props) {
-  const { updateFilterState } = useUpdateFilterState();
+function Filter({ label, name, sectionName }) {
+  const { filters } = useContext(FilterContext)
+  const { setFilterActive } = useUpdateFilterState()
 
   return (
-    <div className="filters__filter js-filter" data-section-name={ props.name } data-name={ props.data.name } data-keys={ props.data.keys.join(',') }>
+    <div className="filters__filter js-filter">
       <label>
-        { props.data.label }
-        <input type="radio" name={ props.name } value={ props.data.name } onChange={ updateFilterState } />
+        {label}
+        <input
+          type="radio"
+          name={name}
+          value={name}
+          onChange={() => setFilterActive(sectionName, name)}
+          checked={
+            filters
+              .find(s => s.name === sectionName)
+              .items
+              .find(f => f.name === name)
+              .active
+          }
+        />
       </label>
     </div>
   );

--- a/src/context/Filter.js
+++ b/src/context/Filter.js
@@ -1,5 +1,16 @@
-import { createContext } from "react";
+import { createContext, useState } from 'react'
+import data from '../data/data.json'
 
-export const FilterContext = createContext([{}, () => {}])
+export const FilterContext = createContext({})
+
+export const FilterProvider = ({ children }) => {
+  const [filters, setFilters] = useState(data.filters)
+
+  return (
+    <FilterContext.Provider value={{ filters, setFilters }}>
+      {children}
+    </FilterContext.Provider>
+  )
+}
 
 export const FilterFunction = createContext([{}, () => {}])

--- a/src/js/Filter.js
+++ b/src/js/Filter.js
@@ -5,32 +5,25 @@ import { useSaveProfile } from "../js/Profile.js";
 const data = require('../data/data.json')
 
 export function useUpdateFilterState (e) {
-  const filterContext = useContext(FilterContext);
+  const { filters, setFilters } = useContext(FilterContext);
   const filterFunction = useContext(FilterFunction);
   const saveProfile = useSaveProfile();
 
-  function updateFilterState (e) {
-    let element = e.target.parentElement.parentElement
-      , sectionName = element.dataset.sectionName
-      , inputName = element.dataset.name;
-
-    for (var i = 0; i < filterContext.length; i++) {
-      let items = filterContext[i].items;
-
-      if (filterContext[i].name == sectionName) {
-        for (var j = 0; j < items.length; j++) {
-          if (items[j].name == inputName) {
-            items[j].active = true;
-          } else {
-            items[j].active = false;
-          }
-        }
+  const setFilterActive = (sectionName, name) => {
+    const newFilters = filters.reduce((acc, section) => [
+      ...acc,
+      {
+        ...section,
+        items: section.name === sectionName
+          ? section.items.map(s => s.name === name ? { ...s, active: true } : { ...s, active: false })
+          : section.items
       }
-    }
-    filterItems(filterContext, filterFunction, saveProfile);
-  }
+    ], [])
 
-  return { updateFilterState };
+    setFilters(newFilters)
+  };
+
+  return { setFilterActive };
 }
 
 export function filterItems (filterState, filterFunction, saveProfile) {


### PR DESCRIPTION
This is just for the filters section, so you'll need to do something similar for the actual list items. Feel free to merge it or just use as reference.

## Changes
- Store filter state in a useState hook in the Filter context

    The idea here is to just hydrate the app with the data.json file, and
    then handle state completely within the app after that. So data.json is
    only accessed once at startup.

- Use more descriptive props in Filters components

    Just makes it easier to see what arguments the component expects.

    I also changed the for loops to `map` calls. Just keeps the mapping
    logic inside the template so you can see the structure of the markup
    better.

- Perform filtering logic on pure data (independent of the DOM)

    In components/Filters.js we pass a `checked` prop to the radio button
    <input>. That way React handles keeping the checked state of the radio
    buttons up to date with the state. All we have to do is manipulate the
    pure data inside the FilterContext (no manual DOM manipulation).